### PR TITLE
compatible low version nodeJs

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,4 +19,5 @@ function arrayTreeFilter(data, filterFn, options) {
   return result;
 }
 
-export default arrayTreeFilter;
+// export default arrayTreeFilter;
+module.exports = arrayTreeFilter;


### PR DESCRIPTION
I  use node v6.9 in my project , it can't recognize "export ". If I switch node version to 8.4 , it's ok.